### PR TITLE
Add Docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM alpine:3.19.0
+
+RUN apk update && \
+    apk upgrade --no-cache && \
+    apk add yarn --no-cache
+
+COPY ../ /app
+
+WORKDIR /app
+
+RUN yarn install
+CMD ["yarn", "start"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+CTN=`which podman >/dev/null 2>&1 && echo podman || echo docker`
+IMAGENAME="itsm-ng_api"
+VERSION="1.6.0"
+
+default: build
+
+build:
+	$(CTN) build -t $(IMAGENAME):$(VERSION) .
+
+build-prod:
+	$(CTN) build -t docker.io/itsmng/$(IMAGENAME):$(VERSION) .
+
+run:
+	$(CTN) run -it --rm -p 8080:80 $(IMAGENAME):$(VERSION)
+
+clean:
+	$(CTN) rmi -f $(IMAGENAME):$(VERSION)


### PR DESCRIPTION
This image is based on Alpine, the size of this image is 643 MB (This size is important because it is JavaScript)

## Documentation

To build the images:
```
make
```

To run 

```
make run
```

To build prod images of DockerHUB
```
make build-prod
```

To remove the images from your computer
```
make clean
```

## Note
- This Makefile work with Podman and Docker cli.